### PR TITLE
make 3 backticks show up in verbatim code chunk

### DIFF
--- a/using-rmd.Rmd
+++ b/using-rmd.Rmd
@@ -118,7 +118,7 @@ We refer to code in an rmarkdown document in two ways, code chunks, and inline c
 Code chunks are marked by three backticks and curly braces with `r` inside them:
 
 ````markdown
-`r ''```{r chunk-name}
+```{r chunk-name}`r ''`
 # a code chunk
 ```
 ````


### PR DESCRIPTION
Hey Nick,

I noticed this:

<img width="784" alt="screen shot 2019-01-22 at 9 42 20 am" src="https://user-images.githubusercontent.com/12160301/51554431-26355580-1e2a-11e9-8c90-516c47d9640d.png">

Fixed with this:

https://yihui.name/en/2017/11/knitr-verbatim-code-chunk/

````
```{r chunk-name}`r ''`
# a code chunk
```
````

So rendered we have 3 backticks:
<img width="287" alt="screen shot 2019-01-22 at 9 44 15 am" src="https://user-images.githubusercontent.com/12160301/51554506-50871300-1e2a-11e9-98a0-0343e7292f3f.png">
